### PR TITLE
<% and <? get tokenized as T_INLINE_HTML though...

### DIFF
--- a/src/Checks/File/BanOpeningTagsCheck.php
+++ b/src/Checks/File/BanOpeningTagsCheck.php
@@ -1,0 +1,73 @@
+<?php
+
+	namespace HippoPHP\Hippo\Checks\Naming;
+
+	use \HippoPHP\Hippo\CheckContext;
+	use \HippoPHP\Hippo\Checks\AbstractCheck;
+	use \HippoPHP\Hippo\Checks\CheckInterface;
+	use \HippoPHP\Hippo\Config\Config;
+
+	class BanOpeningTagsCheck extends AbstractCheck implements CheckInterface {
+		/**
+		 * @var array
+		 */
+		private $_bannedTags = [
+			'<?',
+			'<%'
+		];
+
+		/**
+		 * @return string
+		 */
+		public function getConfigRoot() {
+			return 'file.banned_opening_tags';
+		}
+
+		/**
+		 * Sets the banned tags.
+		 * @param array $tags
+		 * @return BanOpeningTagsCheck
+		 */
+		public function setBannedTags($tags) {
+			$this->_bannedTags = $tags;
+			return $this;
+		}
+
+		/**
+		 * checkFileInternal(): defined by AbstractCheck.
+		 * @see AbstractCheck::checkFileInternal()
+		 * @param CheckContext $checkContext
+		 * @param Config $config
+		 * @return void
+		 */
+		protected function checkFileInternal(CheckContext $checkContext, Config $config) {
+			$file = $checkContext->getFile();
+			$tokens = $checkContext->getTokenList();
+
+			$this->setBannedTags($config->get('tags', $this->_bannedTags));
+
+			if ($tokens->count() > 0) {
+				$token = $tokens->current();
+				if ($this->_checkOpeningTag($token)) {
+					$this->addViolation(
+						$file,
+						trim($token->getLine()),
+						trim($token->getColumn()),
+						sprintf(
+							'Do not use %s as an opening tag',
+							$token->getContent()
+						)
+					);
+				}
+			}
+		}
+
+		/**
+		 * Checks whether the tag matches the requirements.
+		 * @return bool
+		 */
+		private function _checkOpeningTag($token) {
+			$tokenContent = $token->getContent();
+			return $token->isType(T_OPEN_TAG) && in_array($tokenContent, $this->_bannedTags);
+		}
+	}

--- a/src/Standards/base.yml
+++ b/src/Standards/base.yml
@@ -13,6 +13,8 @@ file:
     enabled: false
     style: "tab"
     count: 1
+  banned_opening_tags:
+    enabled: true
 naming:
   bitwise:
     enabled: true


### PR DESCRIPTION
I thought that `token_get_all` would tokenize these tags as `T_OPEN_TAG` as it says on the [List of Parser Tokens](http://php.net/manual/en/tokens.php), but apparently not. Worth keeping?
